### PR TITLE
日期类型精确到秒

### DIFF
--- a/src/Helper/Time.php
+++ b/src/Helper/Time.php
@@ -15,7 +15,7 @@ class Time
         static $dformat, $tformat, $dtformat, $offset, $lang;
         if ($dformat === null) {
             $dformat = 'Y-m-d';
-            $tformat = 'H:i';
+            $tformat = 'H:i:s';
             $dtformat = $dformat . ' ' . $tformat;
             $offset = 8;
             $lang = [


### PR DESCRIPTION
否则在表单编辑日期时间格式会提示格式不正确